### PR TITLE
Apagar Prescrições

### DIFF
--- a/src/model/manager/DeletionsManager.java
+++ b/src/model/manager/DeletionsManager.java
@@ -419,10 +419,17 @@ public class DeletionsManager {
         logging.setModified('Y');
         logging.setTransactionDate(new Date());
         logging.setTransactionType("Delete Prescription");
-        logging.setMessage("Deleted Prescription "
-                + thePrescription.getPrescriptionId() + " from Patient "
-                + thePrescription.getPatient().getPatientId());
+        logging.setMessage("Deleted Prescription " + thePrescription.getPrescriptionId() + " from Patient " + thePrescription.getPatient().getPatientId());
         session.save(logging);
+
+        String updatePrescriptio =  "update Prescription set current = 'T' " +
+                                    " where patient =  " +thePrescription.getPatient().getId()+
+                                    " and date = (select max(date) " +
+                                    "            from Prescription " +
+                                    "               where patient = "+thePrescription.getPatient().getId()+" ) ";
+        session.createQuery(updatePrescriptio).executeUpdate();
+
+
     }
 
     /**

--- a/src/org/celllife/idart/database/dao/ConexaoJDBC.java
+++ b/src/org/celllife/idart/database/dao/ConexaoJDBC.java
@@ -17,6 +17,7 @@ import java.util.Vector;
 import org.apache.log4j.Logger;
 import org.apache.log4j.xml.DOMConfigurator;
 import org.celllife.idart.commonobjects.iDartProperties;
+import org.celllife.idart.database.hibernate.Patient;
 import org.celllife.idart.database.hibernate.PrescriptionToPatient;
 import org.celllife.idart.gui.alert.RiscoRoptura;
 import org.celllife.idart.gui.sync.dispense.SyncLinha;
@@ -4318,6 +4319,25 @@ public class ConexaoJDBC {
         }
 
         return absenteeForSupportCallsXLS;
+
+    }
+
+
+    /**
+     * Actualiza a ultima prescricao para current T depois de remover a current
+     * @param patient
+     * @throws ClassNotFoundException
+     * @throws SQLException
+     */
+    public void updateLastPrescriptionToTrue(Patient patient) throws ClassNotFoundException, SQLException {
+        conecta(iDartProperties.hibernateUsername,
+                iDartProperties.hibernatePassword);
+
+        st.executeUpdate("update prescription set current = 'T' " +
+                " where patient =  " +patient.getId()+
+                " and date = (select max(date) " +
+                "            from prescription " +
+                "               where patient = "+patient.getId()+" ) ");
 
     }
 

--- a/src/org/celllife/idart/gui/deletions/DeleteStockPrescriptionsPackages.java
+++ b/src/org/celllife/idart/gui/deletions/DeleteStockPrescriptionsPackages.java
@@ -1421,8 +1421,9 @@ public class DeleteStockPrescriptionsPackages extends GenericOthersGui {
 		Transaction tx = null;
 		try {
 			tx = getHSession().beginTransaction();
-			DeletionsManager.removeUndispensedPrescription(getHSession(),
-					prescriptionToRemove);
+			DeletionsManager.removeUndispensedPrescription(getHSession(),prescriptionToRemove);
+
+
 			getHSession().flush();
 			tx.commit();
 			MessageBox mb = new MessageBox(getShell());


### PR DESCRIPTION
Quando o gestor eFIla apaga certas prescrições no sistema, ela perde a propriedade T no campo current na tabela prescrição.
Este campo é vital para que o sistema iDART identifica a última prescrição aviada ao paciente, sem esta opção o sistema fecha quando o utilizador tenta salvar uma prescrição.